### PR TITLE
Upgrade emojilib to version 3

### DIFF
--- a/.changeset/violet-adults-share.md
+++ b/.changeset/violet-adults-share.md
@@ -1,0 +1,5 @@
+---
+"nostrudel": patch
+---
+
+Update emojilib

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "chroma-js": "^2.4.2",
     "dayjs": "^1.11.9",
     "debug": "^4.3.4",
-    "emojilib": "2",
+    "emojilib": "3",
     "framer-motion": "^10.16.0",
     "hls.js": "^1.4.14",
     "idb": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "chroma-js": "^2.4.2",
     "dayjs": "^1.11.9",
     "debug": "^4.3.4",
-    "emojilib": "3",
+    "emojilib": "^3",
     "framer-motion": "^10.16.0",
     "hls.js": "^1.4.14",
     "idb": "^8.0.0",

--- a/src/providers/global/emoji-provider.tsx
+++ b/src/providers/global/emoji-provider.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren, createContext, useContext } from "react";
-import { lib } from "emojilib";
+import lib from "emojilib";
 
 import useReplaceableEvents from "../../hooks/use-replaceable-events";
 import useCurrentAccount from "../../hooks/use-current-account";
@@ -7,10 +7,10 @@ import { isEmojiTag } from "../../types/nostr-event";
 import useFavoriteEmojiPacks from "../../hooks/use-favorite-emoji-packs";
 import { getPackCordsFromFavorites } from "../../helpers/nostr/emoji-packs";
 
-const defaultEmojis = Object.entries(lib).map(([name, emojiObject]) => ({
-  ...emojiObject,
-  keywords: [name, ...emojiObject.keywords],
+const defaultEmojis = Object.entries(lib).map(([char, [name, ...keywords]]) => ({
   name,
+  keywords: [name, ...keywords],
+  char,
 }));
 
 export type Emoji = { name: string; keywords: string[]; char: string; url?: string };

--- a/src/types/emojilib.d.ts
+++ b/src/types/emojilib.d.ts
@@ -1,11 +1,4 @@
-type EmojiShape = {
-  keywords: string[];
-  char: string;
-  fitzpatrick_scale: boolean;
-  category: string;
-};
-
 declare module "emojilib" {
-  const lib: { [key: string]: EmojiShape };
-  export { lib };
+  const lib: { [char: string]: string[] };
+  export default lib;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3755,10 +3755,10 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-emojilib@2:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/emojilib/-/emojilib-2.4.0.tgz#ac518a8bb0d5f76dda57289ccb2fdf9d39ae721e"
-  integrity sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==
+emojilib@3:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/emojilib/-/emojilib-3.0.11.tgz#10ba04e72e52e91b960d62f80f8463e2405a1b46"
+  integrity sha512-OuML9z640prB+0Rms1RgzJrBAqNC9mFdqT2HeFcXSGSGNEiZh9adsaPPxWbqRoMyJPzu+zNKPyGKv4/sPmJDyg==
 
 enquirer@^2.3.0:
   version "2.4.1"


### PR DESCRIPTION
emojilib v2 is [too old](https://www.npmjs.com/package/emojilib?activeTab=versions). So many emojis added past 5 years are not available as quick reactions.