### PR TITLE
add root marker by default in channels

### DIFF
--- a/src/views/channels/components/send-message-form.tsx
+++ b/src/views/channels/components/send-message-form.tsx
@@ -39,17 +39,13 @@ export default function ChannelMessageForm({
     let draft: DraftNostrEvent = {
       kind: kinds.ChannelMessage,
       content: values.content,
-      tags: [["e", channel.id]],
+      tags: [["e", rootId || channel.id, "", "root"]],
       created_at: dayjs().unix(),
     };
 
     const contentMentions = getPubkeysMentionedInContent(draft.content);
     draft = createEmojiTags(draft, emojis);
     draft = ensureNotifyPubkeys(draft, contentMentions);
-
-    if (rootId) {
-      draft.tags.push(["e", rootId, "", "root"]);
-    }
 
     setLoadingMessage("Signing...");
     await publish("Send DM", draft, undefined, false);


### PR DESCRIPTION
Thanks for the great app, I enjoy it!  
But I have a problem. The events I post in the app do not show up correctly in other apps.  
I have found that adding a `root` marker in the `e` tag solves the problem.  
Please confirm when you have time, thank you.