### PR TITLE
Added logging and included secret in nsecbunker connect request

### DIFF
--- a/src/services/nostr-connect.ts
+++ b/src/services/nostr-connect.ts
@@ -132,7 +132,9 @@ export class NostrConnectClient {
           p.resolve(response.result);
         }
       }
-    } catch (e) {}
+    } catch (e) {
+        this.log("Error handling event", e);
+    }
   }
 
   private createEvent(content: string, target = this.pubkey, kind = kinds.NostrConnect) {
@@ -280,9 +282,10 @@ class NostrConnectService {
     const pubkey = url.host || url.pathname.replace("//", "");
     if (!isHexKey(pubkey)) throw new Error("Invalid connection URI");
     const relays = url.searchParams.getAll("relay");
+    const secret = url.searchParams.get("secret") ?? undefined;
     if (relays.length === 0) throw new Error("Missing relays");
 
-    return this.getClient(pubkey) || this.createClient(pubkey, relays);
+    return this.getClient(pubkey) || this.createClient(pubkey, relays, secret);
   }
   /** create client from: pubkey#token */
   fromBunkerToken(pubkeyWithToken: string) {

--- a/src/views/signin/nostr-connect.tsx
+++ b/src/views/signin/nostr-connect.tsx
@@ -31,8 +31,8 @@ export default function LoginNostrConnectView() {
       if (uri.startsWith("bunker://")) {
         if (uri.includes("@")) client = nostrConnectService.fromBunkerAddress(uri);
         else client = nostrConnectService.fromBunkerURI(uri);
-
-        await client.connect();
+        
+        await client.connect(client.secretKey);
       } else if (uri.startsWith("npub")) {
         client = nostrConnectService.fromBunkerToken(uri);
         const [npub, hexToken] = uri.split("#");


### PR DESCRIPTION
Updated nsecbunker connect request to include secret from bunker:// connection string.

i.e.

bunker://e0b8dcc860e88d2e0da687d2c801813b03c77d3d87c4bf164416acc59cd257b6?relay=wss://relay.nsecbunker.com&secret=faf68770560f9300346af4393746c7371cfed27bdd5db1155b3f2d35863874fc
