### PR TITLE
Fix pubkey param to nip46 connect call

### DIFF
--- a/src/services/nostr-connect.ts
+++ b/src/services/nostr-connect.ts
@@ -192,7 +192,7 @@ export class NostrConnectClient {
     try {
       const result = await this.makeRequest(
         NostrConnectMethod.Connect,
-        [this.publicKey, token || '', Perms],
+        [this.pubkey, token || '', Perms],
       );
       this.isConnected = true;
       return result;


### PR DESCRIPTION
NIP46 requires remote_user_pubkey as first param. More context: https://github.com/nostrability/nostrability/issues/25#issuecomment-2018748964