### PR TITLE
Fix notification special name

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 stats.html
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1712168706,
+        "narHash": "sha256-XP24tOobf6GGElMd0ux90FEBalUtw6NkBSVh/RlA6ik=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1487bdea619e4a7a53a4590c475deabb5a9d1bfb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-23.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem
+      (system: {
+        devShells =
+          let
+            pkgs = import nixpkgs { inherit system; };
+            inputs = with pkgs; [ nodejs_20 yarn ];
+          in
+          {
+            default = pkgs.mkShell {
+              nativeBuildInputs = inputs;
+            };
+          };
+      });
+}

--- a/src/views/notifications/components/day-group.tsx
+++ b/src/views/notifications/components/day-group.tsx
@@ -1,12 +1,15 @@
 import { MutableRefObject, PropsWithChildren, forwardRef } from "react";
 import { Divider, Flex, Heading, useDisclosure } from "@chakra-ui/react";
 import dayjs from "dayjs";
+import utc from 'dayjs/plugin/utc';
 
 import { ExpandableToggleButton } from "../notification-item";
 
+dayjs.extend(utc);
+
 const specialNames = {
-  [dayjs().startOf("day").unix()]: "Today",
-  [dayjs().subtract(1, "day").startOf("day").unix()]: "Yesterday",
+  [dayjs().utc().startOf("day").unix()]: "Today",
+  [dayjs().utc().subtract(1, "day").startOf("day").unix()]: "Yesterday",
 };
 
 const DayGroup = forwardRef<HTMLDivElement, PropsWithChildren<{ day: number; hideRefOnClose?: boolean }>>(


### PR DESCRIPTION
if not currently in utc, the dayjs function was returning the wrong timestamp for beginning the day. it still had my timezone as part of it. this update uses the utc dayjs plugin to ensure we are using a utc-based comparison since event.created_at in nostr notes are supposed to be in utc time.

also added a basic nix flake file for getting a basic dev environment setup. i can remove this and put these files in the `.gitignore` if that'd be preferred.
