### PR TITLE
update NIP-35: use "x" tag instead of "btih"

### DIFF
--- a/src/helpers/nostr/torrents.ts
+++ b/src/helpers/nostr/torrents.ts
@@ -22,7 +22,7 @@ export function getTorrentTitle(torrent: NostrEvent) {
   return title;
 }
 export function getTorrentBtih(torrent: NostrEvent) {
-  const btih = torrent.tags.find((a) => a[0] === "btih")?.[1];
+  const btih = torrent.tags.find((a) => a[0] === "btih" || a[0] === "x")?.[1];
   if (!btih) throw new Error("Missing btih");
   return btih;
 }

--- a/src/views/torrents/new.tsx
+++ b/src/views/torrents/new.tsx
@@ -107,7 +107,7 @@ export default function NewTorrentView() {
       content: values.description,
       tags: [
         ["title", values.title],
-        ["btih", values.btih],
+        ["x", values.btih],
         ...values.tags.map((v) => ["t", v]),
         ...values.files.map((f) => ["file", f.name, String(f.size)]),
       ],


### PR DESCRIPTION
That's what the [NIP](https://nips.nostr.com/35) say and what [dtan.xyz](https://git.v0l.io/Kieran/dtan/src/commit/dd31d27914902fb025da95b4a84f6b70c939976d/src/nostr-torrent.ts#L140) is doing