### PR TITLE
Rename user "likes" tab to more neutral "reactions"

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -253,7 +253,7 @@ const router = createHashRouter([
           { path: "tracks", element: <UserTracksTab /> },
           { path: "videos", element: <UserVideosTab /> },
           { path: "zaps", element: <UserZapsTab /> },
-          { path: "likes", element: <UserReactionsTab /> },
+          { path: "reactions", element: <UserReactionsTab /> },
           { path: "lists", element: <UserListsTab /> },
           { path: "followers", element: <UserFollowersTab /> },
           { path: "following", element: <UserFollowingTab /> },

--- a/src/views/user/index.tsx
+++ b/src/views/user/index.tsx
@@ -48,7 +48,7 @@ const tabs = [
   { label: "Zaps", path: "zaps" },
   { label: "Lists", path: "lists" },
   { label: "Following", path: "following" },
-  { label: "Likes", path: "likes" },
+  { label: "Reactions", path: "reactions" },
   { label: "Relays", path: "relays" },
   { label: "Goals", path: "goals" },
   { label: "Tracks", path: "tracks" },

--- a/src/views/user/reactions.tsx
+++ b/src/views/user/reactions.tsx
@@ -48,7 +48,7 @@ export default function UserReactionsTab() {
   const contextRelays = useAdditionalRelayContext();
   const readRelays = useReadRelays(contextRelays);
 
-  const timeline = useTimelineLoader(`${pubkey}-likes`, readRelays, { authors: [pubkey], kinds: [7] });
+  const timeline = useTimelineLoader(`${pubkey}-reactions`, readRelays, { authors: [pubkey], kinds: [7] });
 
   const reactions = useSubject(timeline.timeline);
   const callback = useTimelineCurserIntersectionCallback(timeline);


### PR DESCRIPTION
There was some recent discussion that kind 7 reacts aren't necessarily "likes". Someone might react say a poop emoji, or an angry face, and it probably shouldn't be classified as a like emotion. Change the labeling to reflect this.