### PR TITLE
Add feedback for profile edits validation

### DIFF
--- a/src/views/profile/edit.tsx
+++ b/src/views/profile/edit.tsx
@@ -74,8 +74,14 @@ const MetadataForm = ({ defaultValues, onSubmit }: MetadataFormProps) => {
             autoComplete="off"
             isDisabled={isSubmitting}
             {...register("displayName", {
-              minLength: 2,
-              maxLength: 64,
+              minLength: {
+                value: 2,
+                message: "Must be at least 2 characters long",
+              },
+              maxLength: {
+                value: 64,
+                message: "Cannot exceed 64 characters",
+              }
             })}
           />
           <FormErrorMessage>{errors.displayName?.message}</FormErrorMessage>
@@ -86,10 +92,19 @@ const MetadataForm = ({ defaultValues, onSubmit }: MetadataFormProps) => {
             autoComplete="off"
             isDisabled={isSubmitting}
             {...register("username", {
-              minLength: 2,
-              maxLength: 64,
-              required: true,
-              pattern: /^[a-zA-Z0-9_-]{2,64}$/,
+              minLength: {
+                value: 2,
+                message: "Must be at least 2 characters long",
+              },
+              maxLength: {
+                value: 64,
+                message: "Cannot exceed 64 characters",
+              },
+              required: "Username is required",
+              pattern: {
+                value: /^[a-zA-Z0-9_-]{2,64}$/,
+                message: "Only contain letters, numbers, underscores, and hyphens, and must be 2-64 characters",
+              },
             })}
           />
           <FormErrorMessage>{errors.username?.message}</FormErrorMessage>

--- a/src/views/profile/edit.tsx
+++ b/src/views/profile/edit.tsx
@@ -103,7 +103,7 @@ const MetadataForm = ({ defaultValues, onSubmit }: MetadataFormProps) => {
               required: "Username is required",
               pattern: {
                 value: /^[a-zA-Z0-9_-]{2,64}$/,
-                message: "Only contain letters, numbers, underscores, and hyphens, and must be 2-64 characters",
+                message: "Only letters, numbers, underscores, and hyphens, and must be 2-64 characters",
               },
             })}
           />

--- a/src/views/profile/edit.tsx
+++ b/src/views/profile/edit.tsx
@@ -89,7 +89,7 @@ const MetadataForm = ({ defaultValues, onSubmit }: MetadataFormProps) => {
               minLength: 2,
               maxLength: 64,
               required: true,
-              pattern: /^[a-zA-Z0-9_-]{4,64}$/,
+              pattern: /^[a-zA-Z0-9_-]{2,64}$/,
             })}
           />
           <FormErrorMessage>{errors.username?.message}</FormErrorMessage>


### PR DESCRIPTION
* Add messages for user when validation of display name and user name fail
* Make the mininum length for the user name pattern match the minLength of 2

Before:
![nostrudel-before](https://github.com/user-attachments/assets/e0a41ab8-84a8-4c9e-95c6-dfcea2dd6b05)

After:
![nostrudel-after](https://github.com/user-attachments/assets/2acebae8-bad6-4ff5-b5de-5f76d286786c)
