### PR TITLE
feat: Namecoin NIP-05 identity resolution (.bit domains)

### DIFF
--- a/proxy/electrumx-client.mjs
+++ b/proxy/electrumx-client.mjs
@@ -1,0 +1,224 @@
+/**
+ * ElectrumX TCP/TLS client for Namecoin name resolution.
+ *
+ * Protocol: JSON-RPC over newline-delimited TCP.
+ * Used server-side only (Node.js) — browsers connect via the HTTP proxy.
+ */
+
+import { createHash } from "node:crypto";
+import { connect as tlsConnect } from "node:tls";
+
+const OP_NAME_UPDATE = 0x53;
+const NAME_EXPIRE_DEPTH = 36000;
+
+/**
+ * Build the canonical name index script for ElectrumX lookup.
+ *
+ * Script format: OP_NAME_UPDATE <name> <empty> OP_2DROP OP_DROP OP_RETURN
+ * This matches the script pattern that ElectrumX indexes for Namecoin names.
+ */
+export function buildNameScript(fullName) {
+  // fullName is like "d/example" or "id/alice"
+  const nameBytes = Buffer.from(fullName, "utf-8");
+  const parts = [
+    Buffer.from([OP_NAME_UPDATE]),        // OP_NAME_UPDATE
+    pushData(nameBytes),                   // <name>
+    Buffer.from([0x00]),                   // empty (OP_0)
+    Buffer.from([0x6d]),                   // OP_2DROP
+    Buffer.from([0x75]),                   // OP_DROP
+    Buffer.from([0x6a]),                   // OP_RETURN
+  ];
+  return Buffer.concat(parts);
+}
+
+/** Push data with appropriate length prefix */
+function pushData(data) {
+  if (data.length < 0x4c) {
+    return Buffer.concat([Buffer.from([data.length]), data]);
+  } else if (data.length <= 0xff) {
+    return Buffer.concat([Buffer.from([0x4c, data.length]), data]);
+  } else {
+    const lenBuf = Buffer.alloc(3);
+    lenBuf[0] = 0x4d;
+    lenBuf.writeUInt16LE(data.length, 1);
+    return Buffer.concat([lenBuf, data]);
+  }
+}
+
+/**
+ * Compute the scripthash for ElectrumX: SHA-256 of the script, byte-reversed hex.
+ */
+export function computeScripthash(script) {
+  const hash = createHash("sha256").update(script).digest();
+  return Buffer.from(hash.reverse()).toString("hex");
+}
+
+/**
+ * Create a persistent connection to an ElectrumX server.
+ */
+export class ElectrumxClient {
+  constructor(host, port) {
+    this.host = host;
+    this.port = port;
+    this.socket = null;
+    this.requestId = 0;
+    this.pending = new Map();
+    this.buffer = "";
+  }
+
+  async connect() {
+    if (this.socket) return;
+    return new Promise((resolve, reject) => {
+      this.socket = tlsConnect(
+        { host: this.host, port: this.port, rejectUnauthorized: false },
+        () => resolve(),
+      );
+      this.socket.setEncoding("utf-8");
+      this.socket.on("data", (chunk) => this._onData(chunk));
+      this.socket.on("error", (err) => {
+        for (const [, { reject: rej }] of this.pending) rej(err);
+        this.pending.clear();
+        reject(err);
+      });
+      this.socket.on("close", () => {
+        this.socket = null;
+        for (const [, { reject: rej }] of this.pending) rej(new Error("Connection closed"));
+        this.pending.clear();
+      });
+    });
+  }
+
+  _onData(chunk) {
+    this.buffer += chunk;
+    const lines = this.buffer.split("\n");
+    this.buffer = lines.pop() || "";
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const msg = JSON.parse(line);
+        const handler = this.pending.get(msg.id);
+        if (handler) {
+          this.pending.delete(msg.id);
+          if (msg.error) handler.reject(new Error(msg.error.message || JSON.stringify(msg.error)));
+          else handler.resolve(msg.result);
+        }
+      } catch {
+        // ignore malformed lines
+      }
+    }
+  }
+
+  async request(method, params = []) {
+    if (!this.socket) await this.connect();
+    const id = ++this.requestId;
+    const payload = JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n";
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.socket.write(payload);
+    });
+  }
+
+  close() {
+    if (this.socket) {
+      this.socket.destroy();
+      this.socket = null;
+    }
+  }
+
+  /**
+   * Resolve a Namecoin name to its current value.
+   * Returns { value, expired, height } or null if not found.
+   */
+  async resolveName(fullName) {
+    const script = buildNameScript(fullName);
+    const scripthash = computeScripthash(script);
+
+    // Get transaction history for this name's scripthash
+    const history = await this.request("blockchain.scripthash.get_history", [scripthash]);
+    if (!history || !history.length) return null;
+
+    // Get the latest transaction (highest block height)
+    const latest = history.reduce((a, b) => (a.height > b.height ? a : b));
+
+    // Fetch full transaction hex
+    const rawTx = await this.request("blockchain.transaction.get", [latest.tx_hash, false]);
+    if (!rawTx) return null;
+
+    // Parse the NAME_UPDATE value from the transaction
+    const value = parseNameValue(rawTx, fullName);
+    if (value === null) return null;
+
+    // Check expiry
+    const tipHeader = await this.request("blockchain.headers.subscribe", []);
+    const tipHeight = tipHeader?.height || tipHeader?.block_height || 0;
+    const expired = tipHeight > 0 && (tipHeight - latest.height) > NAME_EXPIRE_DEPTH;
+
+    return { value, expired, height: latest.height, txid: latest.tx_hash };
+  }
+}
+
+/**
+ * Parse NAME_UPDATE value from raw transaction hex.
+ *
+ * Scans transaction outputs for the OP_NAME_UPDATE pattern and extracts
+ * the value field (the data stored in the name).
+ */
+function parseNameValue(rawTxHex, expectedName) {
+  const tx = Buffer.from(rawTxHex, "hex");
+  // Simple scan: find OP_NAME_UPDATE byte followed by name push
+  const nameBytes = Buffer.from(expectedName, "utf-8");
+
+  for (let i = 0; i < tx.length - nameBytes.length - 4; i++) {
+    if (tx[i] !== OP_NAME_UPDATE) continue;
+
+    // Try to read pushdata for the name
+    const { data: foundName, nextOffset } = readPushData(tx, i + 1);
+    if (!foundName || !foundName.equals(nameBytes)) continue;
+
+    // Next should be the value pushdata
+    const { data: value } = readPushData(tx, nextOffset);
+    if (value) {
+      try {
+        return value.toString("utf-8");
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+/** Read a Bitcoin script pushdata at the given offset */
+function readPushData(buf, offset) {
+  if (offset >= buf.length) return { data: null, nextOffset: offset };
+  const opcode = buf[offset];
+
+  if (opcode === 0x00) {
+    // OP_0 — empty data
+    return { data: Buffer.alloc(0), nextOffset: offset + 1 };
+  }
+  if (opcode >= 0x01 && opcode <= 0x4b) {
+    // Direct push: opcode is the length
+    const end = offset + 1 + opcode;
+    if (end > buf.length) return { data: null, nextOffset: offset };
+    return { data: buf.subarray(offset + 1, end), nextOffset: end };
+  }
+  if (opcode === 0x4c) {
+    // OP_PUSHDATA1
+    if (offset + 2 > buf.length) return { data: null, nextOffset: offset };
+    const len = buf[offset + 1];
+    const end = offset + 2 + len;
+    if (end > buf.length) return { data: null, nextOffset: offset };
+    return { data: buf.subarray(offset + 2, end), nextOffset: end };
+  }
+  if (opcode === 0x4d) {
+    // OP_PUSHDATA2
+    if (offset + 3 > buf.length) return { data: null, nextOffset: offset };
+    const len = buf.readUInt16LE(offset + 1);
+    const end = offset + 3 + len;
+    if (end > buf.length) return { data: null, nextOffset: offset };
+    return { data: buf.subarray(offset + 3, end), nextOffset: end };
+  }
+
+  return { data: null, nextOffset: offset + 1 };
+}

--- a/proxy/electrumx-proxy.mjs
+++ b/proxy/electrumx-proxy.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * Standalone HTTP proxy for Namecoin ElectrumX name resolution.
+ *
+ * Usage:
+ *   node electrumx-proxy.mjs [--port 3001] [--host nmc2.bitcoins.sk] [--electrumx-port 57001]
+ *
+ * Endpoints:
+ *   GET /lookup/:name  — resolve a Namecoin name (e.g. /lookup/d%2Fexample)
+ *   GET /health        — health check
+ *
+ * For production deployment behind a reverse proxy or CDN.
+ */
+
+import { createServer } from "node:http";
+import { ElectrumxClient } from "./electrumx-client.mjs";
+
+const args = process.argv.slice(2);
+function getArg(name, fallback) {
+  const idx = args.indexOf(`--${name}`);
+  return idx !== -1 && args[idx + 1] ? args[idx + 1] : fallback;
+}
+
+const PORT = parseInt(getArg("port", "3001"), 10);
+const ELECTRUMX_HOST = getArg("host", "nmc2.bitcoins.sk");
+const ELECTRUMX_PORT = parseInt(getArg("electrumx-port", "57001"), 10);
+
+let client = null;
+
+async function getClient() {
+  if (!client) {
+    client = new ElectrumxClient(ELECTRUMX_HOST, ELECTRUMX_PORT);
+    await client.connect();
+  }
+  return client;
+}
+
+// Simple in-memory cache (production should use Redis/similar)
+const resultCache = new Map();
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+const server = createServer(async (req, res) => {
+  // CORS headers
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (url.pathname === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true, server: `${ELECTRUMX_HOST}:${ELECTRUMX_PORT}` }));
+    return;
+  }
+
+  const lookupMatch = url.pathname.match(/^\/lookup\/(.+)$/);
+  if (!lookupMatch) {
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Not found" }));
+    return;
+  }
+
+  const name = decodeURIComponent(lookupMatch[1]);
+
+  // Validate name format
+  if (!name.startsWith("d/") && !name.startsWith("id/")) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Invalid name format. Use d/name or id/name" }));
+    return;
+  }
+
+  // Check cache
+  const cached = resultCache.get(name);
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+    res.writeHead(200, { "Content-Type": "application/json", "X-Cache": "HIT" });
+    res.end(JSON.stringify(cached.data));
+    return;
+  }
+
+  try {
+    const electrumx = await getClient();
+    const result = await electrumx.resolveName(name);
+
+    if (!result) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Name not found", name }));
+      return;
+    }
+
+    const data = {
+      name,
+      value: result.value,
+      expired: result.expired,
+      height: result.height,
+      txid: result.txid,
+    };
+
+    resultCache.set(name, { data, timestamp: Date.now() });
+
+    // Evict old cache entries
+    if (resultCache.size > 1000) {
+      const now = Date.now();
+      for (const [key, val] of resultCache) {
+        if (now - val.timestamp > CACHE_TTL) resultCache.delete(key);
+      }
+    }
+
+    res.writeHead(200, { "Content-Type": "application/json", "X-Cache": "MISS" });
+    res.end(JSON.stringify(data));
+  } catch (err) {
+    console.error(`[proxy] Error resolving ${name}:`, err.message);
+    // Reset client on connection errors
+    if (client) {
+      client.close();
+      client = null;
+    }
+    res.writeHead(502, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "ElectrumX resolution failed", message: err.message }));
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Namecoin ElectrumX proxy listening on http://localhost:${PORT}`);
+  console.log(`ElectrumX server: ${ELECTRUMX_HOST}:${ELECTRUMX_PORT}`);
+  console.log(`Endpoints:`);
+  console.log(`  GET /lookup/d%2Fexample  — resolve d/example`);
+  console.log(`  GET /lookup/id%2Falice   — resolve id/alice`);
+  console.log(`  GET /health              — health check`);
+});
+
+// Graceful shutdown
+process.on("SIGINT", () => {
+  if (client) client.close();
+  server.close();
+  process.exit(0);
+});

--- a/proxy/vite-plugin-namecoin.mjs
+++ b/proxy/vite-plugin-namecoin.mjs
@@ -1,0 +1,96 @@
+/**
+ * Vite dev middleware plugin for Namecoin name resolution.
+ *
+ * Provides /__namecoin/lookup/:name endpoint during development,
+ * so the browser can resolve .bit identities without a separate proxy process.
+ *
+ * Connects to ElectrumX over TLS on first request (lazy init).
+ *
+ * Usage in vite.config.ts:
+ *   import namecoinPlugin from "./proxy/vite-plugin-namecoin.mjs";
+ *   export default defineConfig({ plugins: [namecoinPlugin()] });
+ */
+
+import { ElectrumxClient } from "./electrumx-client.mjs";
+
+const DEFAULT_HOST = "nmc2.bitcoins.sk";
+const DEFAULT_PORT = 57001;
+const CACHE_TTL = 5 * 60 * 1000;
+
+export default function namecoinPlugin(options = {}) {
+  const host = options.host || DEFAULT_HOST;
+  const port = options.port || DEFAULT_PORT;
+
+  let client = null;
+  const cache = new Map();
+
+  async function getClient() {
+    if (!client) {
+      client = new ElectrumxClient(host, port);
+      await client.connect();
+    }
+    return client;
+  }
+
+  return {
+    name: "vite-plugin-namecoin",
+    configureServer(server) {
+      server.middlewares.use("/__namecoin", async (req, res, next) => {
+        // Parse the URL
+        const url = new URL(req.url, "http://localhost");
+        const match = url.pathname.match(/^\/lookup\/(.+)$/);
+
+        if (!match) return next();
+
+        const name = decodeURIComponent(match[1]);
+
+        // Validate format
+        if (!name.startsWith("d/") && !name.startsWith("id/")) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Invalid name format" }));
+          return;
+        }
+
+        // Check cache
+        const cached = cache.get(name);
+        if (cached && Date.now() - cached.ts < CACHE_TTL) {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(cached.data));
+          return;
+        }
+
+        try {
+          const electrumx = await getClient();
+          const result = await electrumx.resolveName(name);
+
+          if (!result) {
+            res.writeHead(404, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "Name not found", name }));
+            return;
+          }
+
+          const data = {
+            name,
+            value: result.value,
+            expired: result.expired,
+            height: result.height,
+            txid: result.txid,
+          };
+
+          cache.set(name, { data, ts: Date.now() });
+
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(data));
+        } catch (err) {
+          console.error(`[namecoin-plugin] Error resolving ${name}:`, err.message);
+          if (client) {
+            client.close();
+            client = null;
+          }
+          res.writeHead(502, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "ElectrumX error", message: err.message }));
+        }
+      });
+    },
+  };
+}

--- a/src/components/icons/namecoin-verified.tsx
+++ b/src/components/icons/namecoin-verified.tsx
@@ -1,0 +1,35 @@
+import { createIcon } from "@chakra-ui/icons";
+
+/**
+ * Namecoin verified icon — shield with checkmark and "N" motif.
+ * Distinct from the standard NIP-05 verified icon to indicate
+ * decentralised blockchain-based identity verification.
+ */
+const NamecoinVerifiedIcon = createIcon({
+  displayName: "NamecoinVerifiedIcon",
+  viewBox: "0 0 24 24",
+  path: (
+    <>
+      {/* Shield outline */}
+      <path
+        d="M12 2L4 5v6.09c0 5.05 3.41 9.76 8 10.91 4.59-1.15 8-5.86 8-10.91V5l-8-3z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Checkmark */}
+      <path
+        d="M9 12l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </>
+  ),
+});
+
+export default NamecoinVerifiedIcon;

--- a/src/components/user/user-dns-identity-icon.tsx
+++ b/src/components/user/user-dns-identity-icon.tsx
@@ -4,7 +4,9 @@ import { IdentityStatus } from "applesauce-loaders/helpers/dns-identity";
 
 import useDnsIdentity from "../../hooks/use-dns-identity";
 import useUserProfile from "../../hooks/use-user-profile";
+import { isNamecoinIdentifier } from "../../services/namecoin";
 import { ErrorIcon, VerificationFailed, VerificationMissing, VerifiedIcon } from "../icons";
+import NamecoinVerifiedIcon from "../icons/namecoin-verified";
 
 const UserDnsIdentityIcon = forwardRef<SVGSVGElement, { pubkey: string } & IconProps>(({ pubkey, ...props }, ref) => {
   const metadata = useUserProfile(pubkey);
@@ -12,17 +14,23 @@ const UserDnsIdentityIcon = forwardRef<SVGSVGElement, { pubkey: string } & IconP
 
   if (!metadata?.nip05) return null;
 
+  const isNmc = isNamecoinIdentifier(metadata.nip05);
+
   switch (identity?.status) {
     case IdentityStatus.Missing:
       return <VerificationMissing color="red.500" {...props} ref={ref} />;
     case IdentityStatus.Error:
       return <ErrorIcon color="yellow.500" {...props} ref={ref} />;
     case IdentityStatus.Found:
-      return identity.pubkey === pubkey ? (
-        <VerifiedIcon color="purple.500" {...props} ref={ref} />
-      ) : (
-        <VerificationFailed color="red.500" {...props} ref={ref} />
-      );
+      if (identity.pubkey === pubkey) {
+        // Namecoin-verified identities get a distinct teal icon
+        return isNmc ? (
+          <NamecoinVerifiedIcon color="teal.400" {...props} ref={ref} />
+        ) : (
+          <VerifiedIcon color="purple.500" {...props} ref={ref} />
+        );
+      }
+      return <VerificationFailed color="red.500" {...props} ref={ref} />;
     default:
       return <VerificationMissing color="blue.500" {...props} ref={ref} />;
   }

--- a/src/hooks/use-dns-identity.ts
+++ b/src/hooks/use-dns-identity.ts
@@ -1,16 +1,34 @@
 import { useAsync } from "react-use";
 import { parseNIP05Address } from "applesauce-core/helpers/dns-identity";
+import { Identity } from "applesauce-loaders/helpers/dns-identity";
 
 import dnsIdentityLoader from "../services/dns-identity-loader";
 import SuperMap from "../classes/super-map";
+import { isNamecoinIdentifier, resolveNamecoin, toIdentity } from "../services/namecoin";
 
 const parseCache = new SuperMap<string, { name: string; domain: string } | null>(parseNIP05Address);
 
-export default function useDnsIdentity(address: string | undefined, force = false) {
-  const parsed = address ? parseCache.get(address) : null;
+export default function useDnsIdentity(address: string | undefined, force = false): Identity | undefined {
+  const isNmc = address ? isNamecoinIdentifier(address) : false;
+  const parsed = address && !isNmc ? parseCache.get(address) : null;
+
   const { value: identity } = useAsync(async () => {
+    if (!address) return undefined;
+
+    // Route .bit / d/ / id/ identifiers to the Namecoin resolver
+    if (isNmc) {
+      try {
+        const result = await resolveNamecoin(address);
+        return toIdentity(address, result);
+      } catch (err) {
+        return toIdentity(address, null, err instanceof Error ? err.message : "Unknown error");
+      }
+    }
+
+    // Standard NIP-05 resolution
     if (parsed) return await dnsIdentityLoader.requestIdentity(parsed.name, parsed.domain);
-  }, [parsed?.name, parsed?.domain]);
+    return undefined;
+  }, [address, isNmc, parsed?.name, parsed?.domain]);
 
   return identity;
 }

--- a/src/hooks/use-namecoin-identity.ts
+++ b/src/hooks/use-namecoin-identity.ts
@@ -1,0 +1,24 @@
+import { useAsync } from "react-use";
+import { Identity } from "applesauce-loaders/helpers/dns-identity";
+
+import { isNamecoinIdentifier, resolveNamecoin, toIdentity } from "../services/namecoin";
+
+/**
+ * React hook to resolve a Namecoin NIP-05 identity (.bit / d/ / id/).
+ * Returns an applesauce Identity object compatible with existing UI.
+ */
+export default function useNamecoinIdentity(address: string | undefined): Identity | undefined {
+  const isNmc = address ? isNamecoinIdentifier(address) : false;
+
+  const { value: identity } = useAsync(async () => {
+    if (!address || !isNmc) return undefined;
+    try {
+      const result = await resolveNamecoin(address);
+      return toIdentity(address, result);
+    } catch (err) {
+      return toIdentity(address, null, err instanceof Error ? err.message : "Unknown error");
+    }
+  }, [address, isNmc]);
+
+  return identity;
+}

--- a/src/services/namecoin/constants.ts
+++ b/src/services/namecoin/constants.ts
@@ -1,0 +1,21 @@
+/** Namecoin protocol constants */
+
+/** Default ElectrumX servers for Namecoin */
+export const DEFAULT_ELECTRUMX_SERVERS = [
+  { host: "nmc2.bitcoins.sk", port: 57001 },
+];
+
+/** Namecoin names expire after this many blocks without renewal */
+export const NAME_EXPIRE_DEPTH = 36000;
+
+/** Default proxy URL — uses Vite dev middleware in development */
+export const DEFAULT_PROXY_PATH = "/__namecoin";
+
+/** Cache TTL in ms (5 minutes) */
+export const DEFAULT_CACHE_TTL = 5 * 60 * 1000;
+
+/** OP codes for Namecoin name scripts */
+export const OP_NAME_UPDATE = 0x53;
+export const OP_2DROP = 0x6d;
+export const OP_DROP = 0x75;
+export const OP_RETURN = 0x6a;

--- a/src/services/namecoin/constants.ts
+++ b/src/services/namecoin/constants.ts
@@ -6,10 +6,16 @@
  * These are public servers that advertise ws:// and wss:// services.
  * The browser connects directly — no backend proxy needed.
  */
-export const DEFAULT_ELECTRUMX_SERVERS: ElectrumxWsServer[] = [
-  { url: "wss://electrumx.testls.space:50004", label: "testls.space" },
-  { url: "ws://electrumx.testls.space:50003", label: "testls.space (plain)" },
-];
+export const DEFAULT_ELECTRUMX_SERVERS: ElectrumxWsServer[] =
+  typeof window !== "undefined" && window.location?.protocol === "https:"
+    ? [
+        { url: "wss://electrumx.testls.space:50004", label: "testls.space" },
+        { url: "ws://electrumx.testls.space:50003", label: "testls.space (plain)" },
+      ]
+    : [
+        { url: "ws://electrumx.testls.space:50003", label: "testls.space (plain)" },
+        { url: "wss://electrumx.testls.space:50004", label: "testls.space" },
+      ];
 
 export interface ElectrumxWsServer {
   /** WebSocket URL (ws:// or wss://) */

--- a/src/services/namecoin/constants.ts
+++ b/src/services/namecoin/constants.ts
@@ -1,15 +1,25 @@
 /** Namecoin protocol constants */
 
-/** Default ElectrumX servers for Namecoin */
-export const DEFAULT_ELECTRUMX_SERVERS = [
-  { host: "nmc2.bitcoins.sk", port: 57001 },
+/**
+ * Default ElectrumX WebSocket servers for Namecoin.
+ *
+ * These are public servers that advertise ws:// and wss:// services.
+ * The browser connects directly — no backend proxy needed.
+ */
+export const DEFAULT_ELECTRUMX_SERVERS: ElectrumxWsServer[] = [
+  { url: "wss://electrumx.testls.space:50004", label: "testls.space" },
+  { url: "ws://electrumx.testls.space:50003", label: "testls.space (plain)" },
 ];
 
-/** Namecoin names expire after this many blocks without renewal */
-export const NAME_EXPIRE_DEPTH = 36000;
+export interface ElectrumxWsServer {
+  /** WebSocket URL (ws:// or wss://) */
+  url: string;
+  /** Human-readable label */
+  label: string;
+}
 
-/** Default proxy URL — uses Vite dev middleware in development */
-export const DEFAULT_PROXY_PATH = "/__namecoin";
+/** Namecoin names expire after this many blocks without renewal (~250 days) */
+export const NAME_EXPIRE_DEPTH = 36000;
 
 /** Cache TTL in ms (5 minutes) */
 export const DEFAULT_CACHE_TTL = 5 * 60 * 1000;

--- a/src/services/namecoin/electrumx-ws.ts
+++ b/src/services/namecoin/electrumx-ws.ts
@@ -29,7 +29,10 @@ import {
 
 /** SHA-256 hash using the browser's Web Crypto API */
 async function sha256(data: Uint8Array): Promise<Uint8Array> {
-  const hash = await crypto.subtle.digest("SHA-256", data);
+  if (!crypto?.subtle) {
+    throw new Error("crypto.subtle unavailable (insecure context?). Use https:// or localhost.");
+  }
+  const hash = await crypto.subtle.digest("SHA-256", data as ArrayBufferView<ArrayBuffer>);
   return new Uint8Array(hash);
 }
 

--- a/src/services/namecoin/electrumx-ws.ts
+++ b/src/services/namecoin/electrumx-ws.ts
@@ -1,0 +1,467 @@
+/**
+ * Browser-native ElectrumX WebSocket client for Namecoin name resolution.
+ *
+ * Connects directly from the browser to ElectrumX servers over WebSocket
+ * (ws:// or wss://) — no backend proxy or server-side code needed.
+ *
+ * Protocol: JSON-RPC 1.0 over WebSocket text frames (newline-delimited).
+ * ElectrumX 1.16.0+ with websockets support required on the server side.
+ *
+ * Resolution strategy:
+ * 1. Build a canonical name index script for the identifier
+ * 2. Compute the Electrum-style scripthash (reversed SHA-256)
+ * 3. Query blockchain.scripthash.get_history to find the latest tx
+ * 4. Fetch the verbose transaction and parse the name value from the script
+ * 5. Check current block height for name expiry
+ */
+
+import {
+  OP_NAME_UPDATE,
+  OP_2DROP,
+  OP_DROP,
+  OP_RETURN,
+  NAME_EXPIRE_DEPTH,
+  DEFAULT_ELECTRUMX_SERVERS,
+  type ElectrumxWsServer,
+} from "./constants";
+
+// ── Crypto helpers (Web Crypto API) ─────────────────────────────────
+
+/** SHA-256 hash using the browser's Web Crypto API */
+async function sha256(data: Uint8Array): Promise<Uint8Array> {
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return new Uint8Array(hash);
+}
+
+/** Convert Uint8Array to hex string */
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** Convert hex string to Uint8Array */
+function hexToBytes(hex: string): Uint8Array {
+  const len = hex.length;
+  const arr = new Uint8Array(len / 2);
+  for (let i = 0; i < len; i += 2) {
+    arr[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  return arr;
+}
+
+// ── Script building ─────────────────────────────────────────────────
+
+/** Bitcoin-style push data encoding */
+function pushData(data: Uint8Array): Uint8Array {
+  const len = data.length;
+  if (len === 0) {
+    // OP_0 for empty push
+    return new Uint8Array([0x00]);
+  }
+  if (len < 0x4c) {
+    const result = new Uint8Array(1 + len);
+    result[0] = len;
+    result.set(data, 1);
+    return result;
+  }
+  if (len <= 0xff) {
+    const result = new Uint8Array(2 + len);
+    result[0] = 0x4c; // OP_PUSHDATA1
+    result[1] = len;
+    result.set(data, 2);
+    return result;
+  }
+  const result = new Uint8Array(3 + len);
+  result[0] = 0x4d; // OP_PUSHDATA2
+  result[1] = len & 0xff;
+  result[2] = (len >> 8) & 0xff;
+  result.set(data, 3);
+  return result;
+}
+
+/**
+ * Build the canonical name index script for ElectrumX lookup.
+ *
+ * Format: OP_NAME_UPDATE <push(name)> <push(empty)> OP_2DROP OP_DROP OP_RETURN
+ *
+ * This matches the script pattern indexed by the Namecoin ElectrumX fork
+ * (electrumx/lib/coins.py: NamecoinMixin.build_name_index_script).
+ */
+function buildNameIndexScript(nameBytes: Uint8Array): Uint8Array {
+  const namePush = pushData(nameBytes);
+  const emptyPush = pushData(new Uint8Array(0)); // empty value → 0x00
+
+  const result = new Uint8Array(1 + namePush.length + emptyPush.length + 3);
+  let offset = 0;
+  result[offset++] = OP_NAME_UPDATE;
+  result.set(namePush, offset);
+  offset += namePush.length;
+  result.set(emptyPush, offset);
+  offset += emptyPush.length;
+  result[offset++] = OP_2DROP;
+  result[offset++] = OP_DROP;
+  result[offset++] = OP_RETURN;
+
+  return result;
+}
+
+/**
+ * Compute the Electrum-style scripthash: SHA-256 of the script, byte-reversed, hex-encoded.
+ */
+async function electrumScripthash(script: Uint8Array): Promise<string> {
+  const hash = await sha256(script);
+  // Reverse in-place
+  hash.reverse();
+  return toHex(hash);
+}
+
+// ── Transaction parsing ─────────────────────────────────────────────
+
+/** Read a push-data encoded byte sequence from script at pos */
+function readPushData(script: Uint8Array, pos: number): { data: Uint8Array; next: number } | null {
+  if (pos >= script.length) return null;
+  const opcode = script[pos];
+
+  if (opcode === 0x00) {
+    return { data: new Uint8Array(0), next: pos + 1 };
+  }
+  if (opcode >= 0x01 && opcode <= 0x4b) {
+    const end = pos + 1 + opcode;
+    if (end > script.length) return null;
+    return { data: script.slice(pos + 1, end), next: end };
+  }
+  if (opcode === 0x4c) {
+    if (pos + 2 > script.length) return null;
+    const len = script[pos + 1];
+    const end = pos + 2 + len;
+    if (end > script.length) return null;
+    return { data: script.slice(pos + 2, end), next: end };
+  }
+  if (opcode === 0x4d) {
+    if (pos + 3 > script.length) return null;
+    const len = script[pos + 1] | (script[pos + 2] << 8);
+    const end = pos + 3 + len;
+    if (end > script.length) return null;
+    return { data: script.slice(pos + 3, end), next: end };
+  }
+  return null;
+}
+
+/** Parse NAME_UPDATE name and value from a verbose transaction response */
+function parseNameFromVerboseTx(
+  txResult: VerboseTxResult,
+  expectedName: string,
+): { name: string; value: string } | null {
+  const nameBytes = new TextEncoder().encode(expectedName);
+
+  for (const vout of txResult.vout || []) {
+    const hex = vout.scriptPubKey?.hex;
+    if (!hex || !hex.startsWith("53")) continue; // Must start with OP_NAME_UPDATE
+
+    const script = hexToBytes(hex);
+    if (script[0] !== OP_NAME_UPDATE) continue;
+
+    // Read name push
+    const nameParsed = readPushData(script, 1);
+    if (!nameParsed) continue;
+
+    // Check name matches
+    if (nameParsed.data.length !== nameBytes.length) continue;
+    let match = true;
+    for (let i = 0; i < nameBytes.length; i++) {
+      if (nameParsed.data[i] !== nameBytes[i]) {
+        match = false;
+        break;
+      }
+    }
+    if (!match) continue;
+
+    // Read value push
+    const valueParsed = readPushData(script, nameParsed.next);
+    if (!valueParsed) continue;
+
+    const name = new TextDecoder("ascii").decode(nameParsed.data);
+    const value = new TextDecoder("utf-8").decode(valueParsed.data);
+    return { name, value };
+  }
+  return null;
+}
+
+// ── WebSocket JSON-RPC client ───────────────────────────────────────
+
+interface HistoryEntry {
+  tx_hash: string;
+  height: number;
+}
+
+interface VerboseTxVout {
+  scriptPubKey?: { hex?: string; asm?: string };
+}
+
+interface VerboseTxResult {
+  vout?: VerboseTxVout[];
+}
+
+interface RpcResponse {
+  jsonrpc?: string;
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+/**
+ * Send a single JSON-RPC request over a fresh WebSocket connection.
+ *
+ * Opens a WebSocket, sends the request, waits for the response, and closes.
+ * This is simple and stateless — appropriate for infrequent name lookups.
+ */
+function wsRpcCall(url: string, method: string, params: unknown[], timeoutMs = 15000): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const ws = new WebSocket(url);
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        ws.close();
+        reject(new Error(`WebSocket timeout after ${timeoutMs}ms`));
+      }
+    }, timeoutMs);
+
+    ws.addEventListener("open", () => {
+      const payload = JSON.stringify({ jsonrpc: "2.0", method, params, id: 1 }) + "\n";
+      ws.send(payload);
+    });
+
+    ws.addEventListener("message", (ev) => {
+      if (settled) return;
+      try {
+        const data = typeof ev.data === "string" ? ev.data : String(ev.data);
+        const msg: RpcResponse = JSON.parse(data.trim());
+        settled = true;
+        clearTimeout(timer);
+        ws.close();
+        if (msg.error) {
+          reject(new Error(msg.error.message || `RPC error ${msg.error.code}`));
+        } else {
+          resolve(msg.result);
+        }
+      } catch (err) {
+        settled = true;
+        clearTimeout(timer);
+        ws.close();
+        reject(err);
+      }
+    });
+
+    ws.addEventListener("error", () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        reject(new Error(`WebSocket connection failed: ${url}`));
+      }
+    });
+
+    ws.addEventListener("close", (ev) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        reject(new Error(`WebSocket closed unexpectedly: code=${ev.code}`));
+      }
+    });
+  });
+}
+
+/**
+ * Batch multiple JSON-RPC calls over a single WebSocket connection.
+ * Sends requests sequentially but keeps the socket open until all are done.
+ */
+function wsRpcBatch(
+  url: string,
+  calls: Array<{ method: string; params: unknown[] }>,
+  timeoutMs = 20000,
+): Promise<unknown[]> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const results: unknown[] = [];
+    let callIndex = 0;
+    let currentId = 0;
+    const ws = new WebSocket(url);
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        ws.close();
+        reject(new Error(`WebSocket batch timeout after ${timeoutMs}ms`));
+      }
+    }, timeoutMs);
+
+    ws.addEventListener("open", () => {
+      // Send the first request
+      sendNext();
+    });
+
+    function sendNext() {
+      if (callIndex >= calls.length) return;
+      currentId = callIndex + 1;
+      const { method, params } = calls[callIndex];
+      ws.send(JSON.stringify({ jsonrpc: "2.0", method, params, id: currentId }) + "\n");
+    }
+
+    ws.addEventListener("message", (ev) => {
+      if (settled) return;
+      try {
+        const data = typeof ev.data === "string" ? ev.data : String(ev.data);
+        const msg: RpcResponse = JSON.parse(data.trim());
+        if (msg.error) {
+          settled = true;
+          clearTimeout(timer);
+          ws.close();
+          reject(new Error(msg.error.message || `RPC error ${msg.error.code}`));
+          return;
+        }
+        results.push(msg.result);
+        callIndex++;
+        if (callIndex >= calls.length) {
+          settled = true;
+          clearTimeout(timer);
+          ws.close();
+          resolve(results);
+        } else {
+          sendNext();
+        }
+      } catch (err) {
+        settled = true;
+        clearTimeout(timer);
+        ws.close();
+        reject(err);
+      }
+    });
+
+    ws.addEventListener("error", () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        reject(new Error(`WebSocket connection failed: ${url}`));
+      }
+    });
+
+    ws.addEventListener("close", (ev) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        reject(new Error(`WebSocket closed unexpectedly: code=${ev.code}`));
+      }
+    });
+  });
+}
+
+// ── Public API ──────────────────────────────────────────────────────
+
+export interface NameShowResult {
+  /** The Namecoin name (e.g. "d/example") */
+  name: string;
+  /** The name's current value (JSON string) */
+  value: string;
+  /** Transaction ID of the latest name_update */
+  txid: string;
+  /** Block height of the latest name_update */
+  height: number;
+  /** Whether the name has expired (>36000 blocks since last update) */
+  expired: boolean;
+  /** Blocks until expiry, or undefined if current height is unknown */
+  expiresIn?: number;
+}
+
+/**
+ * Resolve a Namecoin name via WebSocket to an ElectrumX server.
+ *
+ * Connects directly from the browser — no proxy needed.
+ * Uses a single WebSocket connection for all RPCs in the lookup sequence.
+ *
+ * @param fullName  The Namecoin name, e.g. "d/example" or "id/alice"
+ * @param serverUrl WebSocket URL of the ElectrumX server
+ * @returns NameShowResult if found, null if the name doesn't exist
+ * @throws Error on connection failure or if the name has expired
+ */
+export async function nameShowWs(
+  fullName: string,
+  serverUrl?: string,
+): Promise<NameShowResult | null> {
+  const url = serverUrl || DEFAULT_ELECTRUMX_SERVERS[0].url;
+
+  // 1. Compute scripthash
+  const nameBytes = new TextEncoder().encode(fullName);
+  const script = buildNameIndexScript(nameBytes);
+  const scripthash = await electrumScripthash(script);
+
+  // 2. Negotiate version + get history in one connection
+  const batch1Results = (await wsRpcBatch(url, [
+    { method: "server.version", params: ["noStrudel/0.1", "1.4"] },
+    { method: "blockchain.scripthash.get_history", params: [scripthash] },
+  ])) as [unknown, HistoryEntry[]];
+
+  const history = batch1Results[1];
+  if (!history || !history.length) return null;
+
+  // 3. Get latest transaction + current block height
+  const latest = history.reduce((a, b) => (a.height > b.height ? a : b));
+
+  const batch2Results = (await wsRpcBatch(url, [
+    { method: "blockchain.transaction.get", params: [latest.tx_hash, true] },
+    { method: "blockchain.headers.subscribe", params: [] },
+  ])) as [VerboseTxResult, { height?: number; block_height?: number }];
+
+  const txResult = batch2Results[0];
+  const headersResult = batch2Results[1];
+  const currentHeight = headersResult?.height || headersResult?.block_height || 0;
+
+  // 4. Check expiry
+  const expired = currentHeight > 0 && latest.height > 0 && currentHeight - latest.height >= NAME_EXPIRE_DEPTH;
+  if (expired) {
+    return {
+      name: fullName,
+      value: "",
+      txid: latest.tx_hash,
+      height: latest.height,
+      expired: true,
+      expiresIn: 0,
+    };
+  }
+
+  // 5. Parse name value from transaction
+  const parsed = parseNameFromVerboseTx(txResult, fullName);
+  if (!parsed) return null;
+
+  const expiresIn = currentHeight > 0 && latest.height > 0 ? NAME_EXPIRE_DEPTH - (currentHeight - latest.height) : undefined;
+
+  return {
+    name: parsed.name,
+    value: parsed.value,
+    txid: latest.tx_hash,
+    height: latest.height,
+    expired: false,
+    expiresIn,
+  };
+}
+
+/**
+ * Try multiple servers in order until one succeeds.
+ */
+export async function nameShowWithFallback(
+  fullName: string,
+  servers?: ElectrumxWsServer[],
+): Promise<NameShowResult | null> {
+  const serverList = servers || DEFAULT_ELECTRUMX_SERVERS;
+  let lastError: Error | null = null;
+
+  for (const server of serverList) {
+    try {
+      return await nameShowWs(fullName, server.url);
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      console.warn(`[Namecoin] Server ${server.label} failed:`, lastError.message);
+    }
+  }
+
+  throw lastError || new Error("All ElectrumX servers unreachable");
+}

--- a/src/services/namecoin/index.ts
+++ b/src/services/namecoin/index.ts
@@ -1,0 +1,3 @@
+export { isNamecoinIdentifier, parseNamecoinIdentifier, resolveNamecoin, toIdentity } from "./resolver";
+export type { ParsedNamecoinIdentifier, NamecoinNostrResult, NamecoinSettings } from "./types";
+export { DEFAULT_ELECTRUMX_SERVERS, NAME_EXPIRE_DEPTH, DEFAULT_PROXY_PATH } from "./constants";

--- a/src/services/namecoin/index.ts
+++ b/src/services/namecoin/index.ts
@@ -1,3 +1,4 @@
 export { isNamecoinIdentifier, parseNamecoinIdentifier, resolveNamecoin, toIdentity } from "./resolver";
 export type { ParsedNamecoinIdentifier, NamecoinNostrResult, NamecoinSettings } from "./types";
-export { DEFAULT_ELECTRUMX_SERVERS, NAME_EXPIRE_DEPTH, DEFAULT_PROXY_PATH } from "./constants";
+export { DEFAULT_ELECTRUMX_SERVERS, NAME_EXPIRE_DEPTH } from "./constants";
+export { nameShowWs, nameShowWithFallback } from "./electrumx-ws";

--- a/src/services/namecoin/resolver.ts
+++ b/src/services/namecoin/resolver.ts
@@ -1,0 +1,274 @@
+/**
+ * Namecoin NIP-05 identity resolver
+ *
+ * Resolves .bit domains, d/ and id/ Namecoin names to Nostr pubkeys
+ * by querying an ElectrumX HTTP proxy.
+ */
+
+import { Identity, IdentityStatus } from "applesauce-loaders/helpers/dns-identity";
+import { ParsedNamecoinIdentifier, NamecoinNostrResult } from "./types";
+import { DEFAULT_PROXY_PATH, DEFAULT_CACHE_TTL } from "./constants";
+
+// ── Identifier detection & parsing ──────────────────────────────────
+
+/** Check if a NIP-05-style address is a Namecoin identifier */
+export function isNamecoinIdentifier(address: string): boolean {
+  if (!address) return false;
+  const lower = address.toLowerCase();
+  return lower.endsWith(".bit") || lower.startsWith("d/") || lower.startsWith("id/");
+}
+
+/**
+ * Parse a NIP-05 address or raw Namecoin name into its components.
+ *
+ * Supported formats:
+ *  - alice@example.bit  → d/example, localPart=alice
+ *  - _@example.bit      → d/example, root
+ *  - example.bit        → d/example, root
+ *  - d/example          → d/example, root
+ *  - id/alice           → id/alice
+ */
+export function parseNamecoinIdentifier(raw: string): ParsedNamecoinIdentifier | null {
+  if (!raw) return null;
+  const input = raw.trim().toLowerCase();
+
+  // Direct namespace format: d/name or id/name
+  if (input.startsWith("d/")) {
+    const name = input.slice(2);
+    if (!name) return null;
+    return { namecoinName: `d/${name}`, namespace: "d", name, originalAddress: raw };
+  }
+  if (input.startsWith("id/")) {
+    const name = input.slice(3);
+    if (!name) return null;
+    return { namecoinName: `id/${name}`, namespace: "id", name, originalAddress: raw };
+  }
+
+  // NIP-05 style: [user@]domain.bit
+  if (input.endsWith(".bit")) {
+    const atIndex = input.indexOf("@");
+    let localPart: string | undefined;
+    let domain: string;
+
+    if (atIndex !== -1) {
+      localPart = input.slice(0, atIndex);
+      domain = input.slice(atIndex + 1);
+      // "_" means root (like NIP-05 convention)
+      if (localPart === "_") localPart = undefined;
+    } else {
+      domain = input;
+    }
+
+    // Strip .bit suffix to get the Namecoin d/ name
+    const name = domain.slice(0, -4); // remove ".bit"
+    if (!name) return null;
+
+    return {
+      namecoinName: `d/${name}`,
+      namespace: "d",
+      name,
+      localPart,
+      originalAddress: raw,
+    };
+  }
+
+  return null;
+}
+
+// ── LRU Cache ───────────────────────────────────────────────────────
+
+interface CacheEntry {
+  result: NamecoinNostrResult | null;
+  timestamp: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const MAX_CACHE_SIZE = 200;
+
+function getCached(key: string, ttl: number): NamecoinNostrResult | null | undefined {
+  const entry = cache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() - entry.timestamp > ttl) {
+    cache.delete(key);
+    return undefined;
+  }
+  return entry.result;
+}
+
+function setCache(key: string, result: NamecoinNostrResult | null) {
+  // Simple LRU: delete oldest when over limit
+  if (cache.size >= MAX_CACHE_SIZE) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(key, { result, timestamp: Date.now() });
+}
+
+// ── Proxy resolution ────────────────────────────────────────────────
+
+function getProxyUrl(): string {
+  // Check for explicit env var first, then fall back to dev middleware path
+  if (typeof import.meta !== "undefined" && import.meta.env?.VITE_NAMECOIN_PROXY_URL) {
+    return import.meta.env.VITE_NAMECOIN_PROXY_URL;
+  }
+  return DEFAULT_PROXY_PATH;
+}
+
+/**
+ * Resolve a parsed Namecoin identifier via the ElectrumX HTTP proxy.
+ * Returns null if the name doesn't exist or has no Nostr data.
+ */
+export async function resolveNamecoinViaProxy(
+  parsed: ParsedNamecoinIdentifier,
+  proxyUrl?: string,
+): Promise<NamecoinNostrResult | null> {
+  const base = proxyUrl || getProxyUrl();
+  const url = `${base}/lookup/${encodeURIComponent(parsed.namecoinName)}`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    if (response.status === 404) return null;
+    throw new Error(`Namecoin proxy error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  if (!data || data.expired) return null;
+
+  const value = data.value;
+  if (!value) return null;
+
+  let parsed_value: Record<string, unknown>;
+  try {
+    parsed_value = typeof value === "string" ? JSON.parse(value) : value;
+  } catch {
+    return null;
+  }
+
+  return extractNostrData(parsed_value, parsed);
+}
+
+/**
+ * Extract Nostr pubkey and relays from a Namecoin name value.
+ *
+ * d/ namespace format:
+ *   {"nostr": {"names": {"alice": "hex64"}, "relays": {"hex64": ["wss://..."]}}}
+ *   {"nostr": "hex64"}  (shorthand, root identity)
+ *
+ * id/ namespace format:
+ *   {"nostr": "hex64"}
+ *   {"nostr": {"pubkey": "hex64", "relays": ["wss://..."]}}
+ */
+function extractNostrData(
+  value: Record<string, unknown>,
+  parsed: ParsedNamecoinIdentifier,
+): NamecoinNostrResult | null {
+  const nostr = value.nostr;
+  if (!nostr) return null;
+
+  // id/ namespace
+  if (parsed.namespace === "id") {
+    if (typeof nostr === "string" && isValidHexPubkey(nostr)) {
+      return { pubkey: nostr };
+    }
+    if (typeof nostr === "object" && nostr !== null) {
+      const obj = nostr as Record<string, unknown>;
+      const pubkey = obj.pubkey;
+      if (typeof pubkey === "string" && isValidHexPubkey(pubkey)) {
+        const relays = Array.isArray(obj.relays) ? (obj.relays as string[]) : undefined;
+        return { pubkey, relays };
+      }
+    }
+    return null;
+  }
+
+  // d/ namespace
+  if (typeof nostr === "string" && isValidHexPubkey(nostr)) {
+    // Shorthand: root identity only
+    if (!parsed.localPart) return { pubkey: nostr };
+    return null; // shorthand doesn't support named users
+  }
+
+  if (typeof nostr === "object" && nostr !== null) {
+    const obj = nostr as Record<string, unknown>;
+    const names = obj.names as Record<string, string> | undefined;
+    if (!names) return null;
+
+    // Look up the local part (or "_" for root)
+    const lookupKey = parsed.localPart || "_";
+    const pubkey = names[lookupKey];
+    if (!pubkey || !isValidHexPubkey(pubkey)) return null;
+
+    // Check for relays
+    const relaysMap = obj.relays as Record<string, string[]> | undefined;
+    const relays = relaysMap?.[pubkey];
+
+    return { pubkey, relays: relays?.length ? relays : undefined };
+  }
+
+  return null;
+}
+
+function isValidHexPubkey(s: string): boolean {
+  return /^[0-9a-f]{64}$/.test(s);
+}
+
+// ── Main resolution function ────────────────────────────────────────
+
+/**
+ * Resolve a Namecoin identifier to a Nostr pubkey.
+ * Uses an in-memory LRU cache.
+ */
+export async function resolveNamecoin(
+  address: string,
+  proxyUrl?: string,
+): Promise<NamecoinNostrResult | null> {
+  const parsed = parseNamecoinIdentifier(address);
+  if (!parsed) return null;
+
+  const cacheKey = parsed.localPart
+    ? `${parsed.namecoinName}:${parsed.localPart}`
+    : parsed.namecoinName;
+
+  const cached = getCached(cacheKey, DEFAULT_CACHE_TTL);
+  if (cached !== undefined) return cached;
+
+  try {
+    const result = await resolveNamecoinViaProxy(parsed, proxyUrl);
+    setCache(cacheKey, result);
+    return result;
+  } catch (err) {
+    console.warn("[Namecoin] Resolution failed for", address, err);
+    return null;
+  }
+}
+
+// ── Identity conversion ─────────────────────────────────────────────
+
+/**
+ * Convert a Namecoin resolution result to an applesauce Identity object,
+ * compatible with noStrudel's existing NIP-05 display pipeline.
+ */
+export function toIdentity(
+  address: string,
+  result: NamecoinNostrResult | null,
+  error?: string,
+): Identity {
+  const parsed = parseNamecoinIdentifier(address);
+  const name = parsed?.localPart || parsed?.name || "_";
+  const domain = parsed?.namespace === "id" ? `id/${parsed.name}` : `${parsed?.name || "unknown"}.bit`;
+
+  if (error) {
+    return { name, domain, status: IdentityStatus.Error, error, checked: Date.now() / 1000 };
+  }
+  if (!result) {
+    return { name, domain, status: IdentityStatus.Missing, checked: Date.now() / 1000 };
+  }
+  return {
+    name,
+    domain,
+    status: IdentityStatus.Found,
+    pubkey: result.pubkey,
+    relays: result.relays,
+    checked: Date.now() / 1000,
+  };
+}

--- a/src/services/namecoin/resolver.ts
+++ b/src/services/namecoin/resolver.ts
@@ -2,12 +2,16 @@
  * Namecoin NIP-05 identity resolver
  *
  * Resolves .bit domains, d/ and id/ Namecoin names to Nostr pubkeys
- * by querying an ElectrumX HTTP proxy.
+ * by connecting directly to ElectrumX servers via WebSocket from the browser.
+ *
+ * No backend proxy needed — the browser connects to ElectrumX over ws:// or wss://
+ * and performs the full scripthash-based name lookup natively.
  */
 
 import { Identity, IdentityStatus } from "applesauce-loaders/helpers/dns-identity";
 import { ParsedNamecoinIdentifier, NamecoinNostrResult } from "./types";
-import { DEFAULT_PROXY_PATH, DEFAULT_CACHE_TTL } from "./constants";
+import { DEFAULT_CACHE_TTL } from "./constants";
+import { nameShowWithFallback } from "./electrumx-ws";
 
 // ── Identifier detection & parsing ──────────────────────────────────
 
@@ -104,47 +108,30 @@ function setCache(key: string, result: NamecoinNostrResult | null) {
   cache.set(key, { result, timestamp: Date.now() });
 }
 
-// ── Proxy resolution ────────────────────────────────────────────────
-
-function getProxyUrl(): string {
-  // Check for explicit env var first, then fall back to dev middleware path
-  if (typeof import.meta !== "undefined" && import.meta.env?.VITE_NAMECOIN_PROXY_URL) {
-    return import.meta.env.VITE_NAMECOIN_PROXY_URL;
-  }
-  return DEFAULT_PROXY_PATH;
-}
+// ── WebSocket resolution ────────────────────────────────────────────
 
 /**
- * Resolve a parsed Namecoin identifier via the ElectrumX HTTP proxy.
+ * Resolve a parsed Namecoin identifier via WebSocket to ElectrumX.
+ * Connects directly from the browser — no proxy needed.
  * Returns null if the name doesn't exist or has no Nostr data.
  */
-export async function resolveNamecoinViaProxy(
+export async function resolveNamecoinViaWs(
   parsed: ParsedNamecoinIdentifier,
-  proxyUrl?: string,
 ): Promise<NamecoinNostrResult | null> {
-  const base = proxyUrl || getProxyUrl();
-  const url = `${base}/lookup/${encodeURIComponent(parsed.namecoinName)}`;
+  const result = await nameShowWithFallback(parsed.namecoinName);
+  if (!result || result.expired) return null;
 
-  const response = await fetch(url);
-  if (!response.ok) {
-    if (response.status === 404) return null;
-    throw new Error(`Namecoin proxy error: ${response.status} ${response.statusText}`);
-  }
-
-  const data = await response.json();
-  if (!data || data.expired) return null;
-
-  const value = data.value;
+  const value = result.value;
   if (!value) return null;
 
-  let parsed_value: Record<string, unknown>;
+  let parsedValue: Record<string, unknown>;
   try {
-    parsed_value = typeof value === "string" ? JSON.parse(value) : value;
+    parsedValue = typeof value === "string" ? JSON.parse(value) : value;
   } catch {
     return null;
   }
 
-  return extractNostrData(parsed_value, parsed);
+  return extractNostrData(parsedValue, parsed);
 }
 
 /**
@@ -216,11 +203,10 @@ function isValidHexPubkey(s: string): boolean {
 
 /**
  * Resolve a Namecoin identifier to a Nostr pubkey.
- * Uses an in-memory LRU cache.
+ * Uses an in-memory LRU cache and direct WebSocket connection to ElectrumX.
  */
 export async function resolveNamecoin(
   address: string,
-  proxyUrl?: string,
 ): Promise<NamecoinNostrResult | null> {
   const parsed = parseNamecoinIdentifier(address);
   if (!parsed) return null;
@@ -233,7 +219,7 @@ export async function resolveNamecoin(
   if (cached !== undefined) return cached;
 
   try {
-    const result = await resolveNamecoinViaProxy(parsed, proxyUrl);
+    const result = await resolveNamecoinViaWs(parsed);
     setCache(cacheKey, result);
     return result;
   } catch (err) {

--- a/src/services/namecoin/resolver.ts
+++ b/src/services/namecoin/resolver.ts
@@ -182,7 +182,17 @@ function extractNostrData(
 
     // Look up the local part (or "_" for root)
     const lookupKey = parsed.localPart || "_";
-    const pubkey = names[lookupKey];
+    let pubkey = names[lookupKey];
+
+    // Fallback: bare domain (no localPart) with no "_" entry —
+    // use the sole entry if there's exactly one name registered
+    if (!pubkey && !parsed.localPart) {
+      const entries = Object.entries(names).filter(([, v]) => isValidHexPubkey(v));
+      if (entries.length === 1) {
+        pubkey = entries[0][1];
+      }
+    }
+
     if (!pubkey || !isValidHexPubkey(pubkey)) return null;
 
     // Check for relays

--- a/src/services/namecoin/types.ts
+++ b/src/services/namecoin/types.ts
@@ -1,0 +1,29 @@
+/** Namecoin NIP-05 identity resolution types */
+
+/** Result of resolving a Namecoin name's Nostr data */
+export interface NamecoinNostrResult {
+  pubkey: string;
+  relays?: string[];
+}
+
+/** Parsed Namecoin identifier */
+export interface ParsedNamecoinIdentifier {
+  /** The raw Namecoin name, e.g. "d/example" or "id/alice" */
+  namecoinName: string;
+  /** Namespace: "d" (domain) or "id" (identity) */
+  namespace: "d" | "id";
+  /** The name within the namespace, e.g. "example" */
+  name: string;
+  /** Local part for domain namespace (from user@domain.bit), undefined for root */
+  localPart?: string;
+  /** Original NIP-05 style address if applicable */
+  originalAddress?: string;
+}
+
+/** Settings for the Namecoin resolver */
+export interface NamecoinSettings {
+  /** URL of the ElectrumX HTTP proxy */
+  proxyUrl: string;
+  /** Cache TTL in milliseconds (default: 5 minutes) */
+  cacheTtl?: number;
+}

--- a/src/services/namecoin/types.ts
+++ b/src/services/namecoin/types.ts
@@ -22,8 +22,8 @@ export interface ParsedNamecoinIdentifier {
 
 /** Settings for the Namecoin resolver */
 export interface NamecoinSettings {
-  /** URL of the ElectrumX HTTP proxy */
-  proxyUrl: string;
+  /** Custom ElectrumX WebSocket servers (overrides defaults) */
+  servers?: Array<{ url: string; label: string }>;
   /** Cache TTL in milliseconds (default: 5 minutes) */
   cacheTtl?: number;
 }

--- a/src/views/search/index.tsx
+++ b/src/views/search/index.tsx
@@ -8,6 +8,8 @@ import { CopyToClipboardIcon, SearchIcon, SettingsIcon } from "../../components/
 import QRCodeScannerButton from "../../components/qr-code/qr-code-scanner-button";
 import VerticalPageLayout from "../../components/vertical-page-layout";
 import { safeDecode } from "../../helpers/nip19";
+import { isNamecoinIdentifier, resolveNamecoin } from "../../services/namecoin";
+import { nip19 } from "nostr-tools";
 import { getMatchHashtag } from "../../helpers/regexp";
 import useSearchRelays, { useCacheRelaySupportsSearch } from "../../hooks/use-search-relays";
 import { useBreakpointValue } from "../../providers/global/breakpoint-provider";
@@ -50,6 +52,22 @@ export function SearchPage() {
     const hashTagMatch = getMatchHashtag().exec(cleanText);
     if (hashTagMatch) {
       navigate({ pathname: "/t/" + hashTagMatch[2].toLocaleLowerCase() }, { replace: true });
+      return true;
+    }
+
+    // Resolve Namecoin .bit / d/ / id/ identifiers via ElectrumX
+    if (isNamecoinIdentifier(cleanText)) {
+      resolveNamecoin(cleanText)
+        .then((result) => {
+          if (result?.pubkey) {
+            const target = "/u/" + nip19.npubEncode(result.pubkey);
+            console.log("[Namecoin] Navigating to", target);
+            window.location.href = target;
+          } else {
+            console.warn("[Namecoin] No pubkey found for", cleanText);
+          }
+        })
+        .catch((err) => console.warn("[Namecoin] Search resolve failed:", err));
       return true;
     }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 import tsconfigPaths from "vite-tsconfig-paths";
+import namecoinPlugin from "./proxy/vite-plugin-namecoin.mjs";
 
 console.log("Build with:");
 for (const [key, value] of Object.entries(process.env)) {
@@ -34,6 +35,8 @@ export default defineConfig({
   plugins: [
     react(),
     tsconfigPaths(),
+    // Namecoin ElectrumX proxy — zero-setup .bit identity resolution in dev
+    namecoinPlugin(),
     VitePWA({
       strategies: "injectManifest",
       srcDir: "src/sw/worker",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 import tsconfigPaths from "vite-tsconfig-paths";
-import namecoinPlugin from "./proxy/vite-plugin-namecoin.mjs";
 
 console.log("Build with:");
 for (const [key, value] of Object.entries(process.env)) {
@@ -35,8 +34,6 @@ export default defineConfig({
   plugins: [
     react(),
     tsconfigPaths(),
-    // Namecoin ElectrumX proxy — zero-setup .bit identity resolution in dev
-    namecoinPlugin(),
     VitePWA({
       strategies: "injectManifest",
       srcDir: "src/sw/worker",


### PR DESCRIPTION
## Namecoin NIP-05 Identity Resolution

This PR adds decentralised NIP-05-style identity verification via the [Namecoin](https://www.namecoin.org/) blockchain, enabling `.bit` domain identities without any centralised HTTP server.

### What is Namecoin?

Namecoin is a decentralised naming blockchain (the first Bitcoin fork). Names in the `d/` (domain) and `id/` (identity) namespaces can store arbitrary JSON data, including Nostr public keys and relay lists. This enables censorship-resistant NIP-05 verification — no domain registrar or web server needed.

### Architecture — Browser-Native (No Backend)

```
Browser ──WebSocket──▶ ElectrumX Server ──▶ Namecoin Blockchain
```

The browser connects **directly** to ElectrumX servers via WebSocket (`wss://` or `ws://`). No backend proxy, no server-side code, no middleware — works with noStrudel deployed as a fully static web app.

The resolution flow in the browser:
1. Build a canonical name index script for the Namecoin identifier
2. Compute the scripthash using the Web Crypto API (`crypto.subtle.digest("SHA-256", ...)`)
3. Query `blockchain.scripthash.get_history` over WebSocket to find the latest `name_update` transaction
4. Fetch the verbose transaction and parse the `NAME_UPDATE` script to extract the name value (JSON)
5. Check current block height via `blockchain.headers.subscribe` for name expiry (Namecoin names expire after 36,000 blocks / ~250 days)
6. Extract Nostr pubkey and relays from the name's JSON value

### ElectrumX WebSocket Support

Tested and verified working with `electrumx.testls.space` (ElectrumX 1.16.0):
- **WSS :50004** ✅ — encrypted, preferred
- **WS :50003** ✅ — plaintext fallback
- `server.features` advertises both `ws://` and `wss://` services
- Full end-to-end name resolution confirmed for `d/bitcoin` and `d/testls`

The client uses batched RPC calls over a single WebSocket connection per lookup (4 RPCs: version negotiation, history, transaction, headers — batched into 2 connections).

### Supported Identifier Formats

| Input | Namecoin Name | Lookup |
|-------|--------------|--------|
| `alice@example.bit` | `d/example` | `nostr.names.alice` |
| `_@example.bit` | `d/example` | Root identity |
| `example.bit` | `d/example` | Root identity |
| `d/example` | `d/example` | Direct lookup |
| `id/alice` | `id/alice` | Identity namespace |

### Namecoin Value Format

**d/ namespace** (NIP-05 compatible):
```json
{"nostr": {"names": {"alice": "<hex-pubkey>"}, "relays": {"<hex-pubkey>": ["wss://..."]}}}
```

**id/ namespace**:
```json
{"nostr": {"pubkey": "<hex-pubkey>", "relays": ["wss://..."]}}
```

### Changes

**Browser-side (all that's needed):**
- `src/services/namecoin/electrumx-ws.ts` — Browser-native WebSocket ElectrumX client (scripthash computation, transaction parsing, name resolution — all using Web APIs)
- `src/services/namecoin/resolver.ts` — Resolver with LRU cache, identifier parsing, Nostr data extraction
- `src/services/namecoin/constants.ts` — WebSocket server list, protocol constants
- `src/services/namecoin/types.ts` — Type definitions
- `src/hooks/use-dns-identity.ts` — Routes `.bit`/`d/`/`id/` identifiers to Namecoin resolver
- `src/hooks/use-namecoin-identity.ts` — Standalone Namecoin identity hook
- `src/components/icons/namecoin-verified.tsx` — Distinct shield icon for Namecoin-verified identities
- `src/components/user/user-dns-identity-icon.tsx` — Teal icon for Namecoin vs purple for standard NIP-05

**Server-side proxy (kept for reference, not imported):**
- `proxy/electrumx-client.mjs` — Node.js TLS client (no longer used)
- `proxy/electrumx-proxy.mjs` — Standalone HTTP proxy (no longer used)
- `proxy/vite-plugin-namecoin.mjs` — Vite dev middleware (removed from vite.config.ts)

### Development

Just `pnpm dev` — the browser connects directly to public ElectrumX WebSocket servers. No proxy setup needed. Set a NIP-05 address ending in `.bit` on any profile to test.

### Production

Nothing extra needed — the browser handles everything. The default server list includes `electrumx.testls.space` with WSS support.

### Related

- [Amethyst](https://github.com/vitorpamplona/amethyst) — Android Nostr client with Namecoin NIP-05 support (uses TCP/TLS)
- [Coracle PR #662](https://github.com/coracle-social/coracle/pull/662) — Similar Namecoin NIP-05 integration
- [NIP-05 spec](https://github.com/nostr-protocol/nips/blob/master/05.md)
- [Namecoin](https://www.namecoin.org/) — Decentralised naming blockchain