### PR TITLE
fix(notifications): show @names for nostr mentions in previews

### DIFF
--- a/src/views/notifications/components/event-preview-text.tsx
+++ b/src/views/notifications/components/event-preview-text.tsx
@@ -1,0 +1,34 @@
+import { Box, BoxProps, Text } from "@chakra-ui/react";
+import { getTagValue } from "applesauce-core/helpers";
+import { useRenderedContent } from "applesauce-react/hooks";
+import { NostrEvent } from "nostr-tools";
+import { memo } from "react";
+
+import { onlyLinkComponents } from "../../../components/content";
+
+const PreviewContentSymbol = Symbol.for("event-preview-text");
+
+/**
+ * Renders an event's title if it has one, or a single-line content preview.
+ * Nostr mentions (npub / nprofile) are rendered as @names instead of raw bech32 ids
+ */
+function EventPreviewText({ event, ...props }: { event: NostrEvent } & BoxProps) {
+  const title = getTagValue(event, "title");
+  const content = useRenderedContent(event, onlyLinkComponents, { cacheKey: PreviewContentSymbol });
+
+  if (title) {
+    return (
+      <Text isTruncated {...props}>
+        {title}
+      </Text>
+    );
+  }
+
+  return (
+    <Box isTruncated {...props}>
+      {content}
+    </Box>
+  );
+}
+
+export default memo(EventPreviewText);

--- a/src/views/notifications/replies/components/reply-card.tsx
+++ b/src/views/notifications/replies/components/reply-card.tsx
@@ -9,6 +9,7 @@ import { CompactNoteContent } from "../../../../components/compact-note-content"
 import HoverLinkOverlay from "../../../../components/hover-link-overlay";
 import RouterLink from "../../../../components/router-link";
 import Timestamp from "../../../../components/timestamp";
+import EventPreviewText from "../../components/event-preview-text";
 import UserAvatar from "../../../../components/user/user-avatar";
 import UserName from "../../../../components/user/user-name";
 import useEvent from "../../../../hooks/use-event";
@@ -25,7 +26,7 @@ function ParentPreview({ event, ...props }: { event: NostrEvent } & Omit<FlexPro
 
   return (
     <Flex gap="2" fontSize="sm" color="GrayText" fontStyle="italic" overflow="hidden" {...props}>
-      <Text isTruncated>{parent.content}</Text>
+      <EventPreviewText event={parent} />
     </Flex>
   );
 }

--- a/src/views/notifications/reposts/components/repost-group.tsx
+++ b/src/views/notifications/reposts/components/repost-group.tsx
@@ -1,5 +1,5 @@
 import { AvatarGroup, Flex, LinkBox, Text } from "@chakra-ui/react";
-import { getTagValue, naddrEncode, neventEncode } from "applesauce-core/helpers";
+import { naddrEncode, neventEncode } from "applesauce-core/helpers";
 import { getSharedEventPointer } from "applesauce-common/helpers";
 import { getEmbededSharedEvent } from "applesauce-common/helpers/share";
 import { memo, useEffect, useMemo } from "react";
@@ -7,6 +7,7 @@ import { memo, useEffect, useMemo } from "react";
 import HoverLinkOverlay from "../../../../components/hover-link-overlay";
 import RouterLink from "../../../../components/router-link";
 import Timestamp from "../../../../components/timestamp";
+import EventPreviewText from "../../components/event-preview-text";
 import UserAvatarLink from "../../../../components/user/user-avatar-link";
 import UserName from "../../../../components/user/user-name";
 import useEventIntersectionRef from "../../../../hooks/use-event-intersection-ref";
@@ -56,9 +57,7 @@ function RepostGroup({ group }: { group: TRepostGroup }) {
       {sharedEvent ? (
         <Flex overflow="hidden" alignItems="center" gap="2">
           <UserName pubkey={sharedEvent.pubkey} fontWeight="bold" />
-          <Text fontSize="sm" color="TextGray" isTruncated flex={1}>
-            {getTagValue(sharedEvent, "title") || sharedEvent.content}
-          </Text>
+          <EventPreviewText event={sharedEvent} fontSize="sm" color="TextGray" flex={1} />
           <Timestamp timestamp={group.latest} />
         </Flex>
       ) : (

--- a/src/views/notifications/threads/components/thread-group.tsx
+++ b/src/views/notifications/threads/components/thread-group.tsx
@@ -1,10 +1,11 @@
 import { AvatarGroup, Flex, LinkBox, Text } from "@chakra-ui/react";
-import { neventEncode, naddrEncode, getTagValue, isAddressPointer } from "applesauce-core/helpers";
+import { neventEncode, naddrEncode, isAddressPointer } from "applesauce-core/helpers";
 import { memo, useMemo } from "react";
 
 import HoverLinkOverlay from "../../../../components/hover-link-overlay";
 import RouterLink from "../../../../components/router-link";
 import Timestamp from "../../../../components/timestamp";
+import EventPreviewText from "../../components/event-preview-text";
 import UserAvatarLink from "../../../../components/user/user-avatar-link";
 import UserName from "../../../../components/user/user-name";
 import useSingleEvent from "../../../../hooks/use-single-event";
@@ -63,9 +64,7 @@ function ThreadGroup({ group }: { group: ThreadGroupData }) {
       {rootEvent ? (
         <HoverLinkOverlay as={RouterLink} to={link} display="flex" alignItems="center" gap="2">
           <UserName pubkey={rootEvent.pubkey} />
-          <Text fontSize="sm" color="gray.500" isTruncated flex={1}>
-            {getTagValue(rootEvent, "title") || rootEvent.content}
-          </Text>
+          <EventPreviewText event={rootEvent} fontSize="sm" color="gray.500" flex={1} />
           <Timestamp timestamp={group.latest} />
         </HoverLinkOverlay>
       ) : (

--- a/src/views/notifications/zaps/components/zap-group.tsx
+++ b/src/views/notifications/zaps/components/zap-group.tsx
@@ -1,12 +1,13 @@
 import { Box, Flex, LinkBox, Text } from "@chakra-ui/react";
 import { ZapEvent } from "applesauce-common/helpers";
-import { getTagValue, naddrEncode, neventEncode } from "applesauce-core/helpers";
+import { naddrEncode, neventEncode } from "applesauce-core/helpers";
 import { getZapAmount, getZapPayment, getZapSender } from "applesauce-common/helpers";
 import { memo, useMemo } from "react";
 
 import HoverLinkOverlay from "../../../../components/hover-link-overlay";
 import RouterLink from "../../../../components/router-link";
 import Timestamp from "../../../../components/timestamp";
+import EventPreviewText from "../../components/event-preview-text";
 import UserAvatar from "../../../../components/user/user-avatar";
 import UserName from "../../../../components/user/user-name";
 import ValueDisplay from "../../../../components/value-display";
@@ -50,9 +51,7 @@ function ZapGroup({ group }: { group: TZapGroup }) {
       {event ? (
         <Flex overflow="hidden" alignItems="center" gap="2">
           <UserName pubkey={event.pubkey} fontWeight="bold" />
-          <Text fontSize="sm" color="gray.500" isTruncated flex={1}>
-            {getTagValue(event, "title") || event.content}
-          </Text>
+          <EventPreviewText event={event} fontSize="sm" color="gray.500" flex={1} />
           <Timestamp timestamp={group.latest} />
         </Flex>
       ) : (


### PR DESCRIPTION
Closes #320

Notification previews rendered raw event content, so notes that mention someone with an `nprofile` (or `npub`) showed the raw bech32 id instead of a name.

This adds a shared `EventPreviewText` component that renders the event's title when present, or a single-line content preview through applesauce's content pipeline with `onlyLinkComponents` — so mentions resolve to `@name` (via `UserLink`) just like they do in the full note view.

Updated all notification surfaces that rendered raw `.content`:
- replies: parent note preview
- zaps: zapped note row
- reposts: shared note row
- threads: thread root row

Verified with `tsc --noEmit` (only pre-existing errors in `src/services/verify-event.ts` from a duplicate nostr-tools version remain) and prettier.

Fully AI-assisted.